### PR TITLE
feat: add Dropbox access token refresh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ node auth.js
 4. It will instruct you to open a browser and navigate to `http://localhost:3000/auth`. Follow that. You may be requested to confirm auth for this module.
 5. After auth, the `credentials.json` file would be created.
 
+The auth script requests an offline Dropbox token and stores both an access token and a refresh token in `credentials.json`. The module automatically refreshes the access token before it expires, and retries once after a Dropbox `401` response by refreshing the token. Keep `DROPBOX_APP_KEY` and `DROPBOX_APP_SECRET` in `.env`, and make sure the MagicMirror process can write to `credentials.json` because refreshed access tokens are saved back to that file.
+
 ### 3. Get LocationIQ API Key (optional)
 
 1. Visit http://locationiq.org and sign up.

--- a/auth.js
+++ b/auth.js
@@ -27,7 +27,7 @@ app.get("/", (req, res) => {
     response_type: 'code',
     redirect_uri: redirectUri,
     token_access_type: 'offline', // For refresh token
-    scope: 'files.metadata.read files.content.read files.content.write',
+    scope: 'files.metadata.read files.content.read',
     code_challenge: pkce.codeChallenge,
     code_challenge_method: 'S256',
     include_granted_scopes: 'user'

--- a/node_helper.js
+++ b/node_helper.js
@@ -8,6 +8,8 @@ const LOCATIONIQ_URL = 'https://us1.locationiq.org/v1/reverse?'
 const GEO_CACHE_LIMIT = 5000
 const DROPBOX_API_BASE = 'https://api.dropboxapi.com/2'
 const DROPBOX_CONTENT_BASE = 'https://content.dropboxapi.com/2'
+const DROPBOX_TOKEN_URL = 'https://api.dropboxapi.com/oauth2/token'
+const TOKEN_REFRESH_MARGIN = 60_000
 
 var log = () => { }
 
@@ -17,6 +19,7 @@ const NodeHelper = require('node_helper')
 module.exports = NodeHelper.create({
   start: function () {
     this.credentials = require('./credentials.json')
+    this.credentialsPath = path.resolve(__dirname, 'credentials.json')
   },
 
   socketNotificationReceived: async function (noti, payload) {
@@ -41,8 +44,76 @@ module.exports = NodeHelper.create({
     this.sendSocketNotification('INITIALIZED')
   },
 
+  isAccessTokenExpired: function () {
+    if (!this.credentials.expires_at) return false
+    return Date.now() + TOKEN_REFRESH_MARGIN >= this.credentials.expires_at
+  },
+
+  saveCredentials: function () {
+    fs.writeFileSync(this.credentialsPath, JSON.stringify(this.credentials, null, 2))
+  },
+
+  refreshAccessToken: async function () {
+    if (!this.credentials.refresh_token) return
+    if (!process.env.DROPBOX_APP_KEY) {
+      throw new Error('DROPBOX_APP_KEY is required to refresh Dropbox access tokens.')
+    }
+    if (this.refreshPromise) return this.refreshPromise
+
+    this.refreshPromise = (async () => {
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: this.credentials.refresh_token,
+        client_id: process.env.DROPBOX_APP_KEY,
+      })
+
+      if (process.env.DROPBOX_APP_SECRET) {
+        body.set('client_secret', process.env.DROPBOX_APP_SECRET)
+      }
+
+      const response = await fetch(DROPBOX_TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body,
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(`Dropbox token refresh failed (${response.status}): ${errorText}`)
+      }
+
+      const tokenData = await response.json()
+      this.credentials = {
+        ...this.credentials,
+        access_token: tokenData.access_token,
+        expires_in: tokenData.expires_in,
+        expires_at: Date.now() + tokenData.expires_in * 1000 - 10000,
+        token_type: tokenData.token_type ?? this.credentials.token_type,
+        scope: tokenData.scope ?? this.credentials.scope,
+        refreshed_at: new Date().toISOString(),
+      }
+      this.accessToken = this.credentials.access_token
+      this.saveCredentials()
+      log('[DBXP] Dropbox access token refreshed.')
+    })().finally(() => {
+      this.refreshPromise = null
+    })
+
+    return this.refreshPromise
+  },
+
+  ensureAccessToken: async function () {
+    if (this.isAccessTokenExpired()) {
+      await this.refreshAccessToken()
+    }
+  },
+
   // Helper function to make Dropbox API calls
-  dropboxRequest: async function(endpoint, body = null, useContentApi = false) {
+  dropboxRequest: async function(endpoint, body = null, useContentApi = false, retry = true) {
+    await this.ensureAccessToken()
+
     const baseUrl = useContentApi ? DROPBOX_CONTENT_BASE : DROPBOX_API_BASE
     const url = `${baseUrl}${endpoint}`
     
@@ -59,6 +130,11 @@ module.exports = NodeHelper.create({
     }
     
     const response = await fetch(url, options)
+
+    if (response.status === 401 && retry && this.credentials.refresh_token) {
+      await this.refreshAccessToken()
+      return this.dropboxRequest(endpoint, body, useContentApi, false)
+    }
     
     if (!response.ok) {
       const errorText = await response.text()
@@ -69,7 +145,9 @@ module.exports = NodeHelper.create({
   },
 
   // Helper function for content downloads
-  dropboxDownload: async function(endpoint, body) {
+  dropboxDownload: async function(endpoint, body, retry = true) {
+    await this.ensureAccessToken()
+
     const url = `${DROPBOX_CONTENT_BASE}${endpoint}`
     
     const options = {
@@ -81,6 +159,11 @@ module.exports = NodeHelper.create({
     }
     
     const response = await fetch(url, options)
+
+    if (response.status === 401 && retry && this.credentials.refresh_token) {
+      await this.refreshAccessToken()
+      return this.dropboxDownload(endpoint, body, false)
+    }
     
     if (!response.ok) {
       const errorText = await response.text()


### PR DESCRIPTION
## Summary
- refresh Dropbox access tokens automatically when `credentials.json` contains an offline refresh token
- retry Dropbox API/content calls once after a 401 by refreshing the token
- persist refreshed access token metadata back to `credentials.json`
- request only Dropbox read scopes in `auth.js`
- document the writable `credentials.json` runtime requirement

## Validation
- Deployed and tested locally.
- Verified logs show `[DBXP] Dropbox access token refreshed.`, 22 files scanned, and images downloaded/served successfully.
- Verified `credentials.json` was updated with `refreshed_at: 2026-06-27T22:08:50.702Z` and new expiry `2026-06-28T02:08:40.702Z`.
- Ran `node --check auth.js` and `node --check node_helper.js`.
- Ran `npx prettier README.md auth.js node_helper.js --check`.
- Earlier focused ESLint passed for `node_helper.js`; later ESLint invocations hung locally, so parser and formatting checks were used for the final `auth.js` scope-only change.

## Note
`npm test` currently reaches Prettier and fails on pre-existing `CHANGELOG.md` formatting unrelated to this patch.